### PR TITLE
fix: Remove `baseUrl` and rewrite absolute imports to relative ones

### DIFF
--- a/packages/nauth0/src/browser/SessionProvider.ts
+++ b/packages/nauth0/src/browser/SessionProvider.ts
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Session } from 'lib';
+import { Session } from '../lib';
 
 export const SessionContext = React.createContext<Session | undefined>(
   undefined

--- a/packages/nauth0/src/browser/index.ts
+++ b/packages/nauth0/src/browser/index.ts
@@ -1,5 +1,5 @@
-import { Session } from 'lib';
-import { NAuth0Client } from 'client';
+import { Session } from '../lib';
+import { NAuth0Client } from '../client';
 import { NextApiHandler } from 'next';
 
 class BrowserNAuth0Client implements NAuth0Client {

--- a/packages/nauth0/src/browser/useSession.test.tsx
+++ b/packages/nauth0/src/browser/useSession.test.tsx
@@ -4,7 +4,7 @@ import { useSession } from './useSession';
 import { SessionProvider } from './SessionProvider';
 import { rest } from 'msw';
 import { setupServer } from 'msw/node';
-import { Session } from 'lib';
+import { Session } from '../lib';
 import '@testing-library/jest-dom'; // TODO: How can I import the type definitions for extend-expect automatically?
 
 const App: React.FC = () => {

--- a/packages/nauth0/src/browser/useSession.ts
+++ b/packages/nauth0/src/browser/useSession.ts
@@ -1,5 +1,5 @@
 import { useContext, useEffect, useState } from 'react';
-import { Session } from 'lib';
+import { Session } from '../lib';
 import { SessionContext } from './SessionProvider';
 import fetch from 'unfetch';
 

--- a/packages/nauth0/src/index.browser.ts
+++ b/packages/nauth0/src/index.browser.ts
@@ -6,3 +6,4 @@ export default (): NAuth0Client => {
 };
 
 export * from './browser';
+export * from './lib';

--- a/packages/nauth0/src/index.ts
+++ b/packages/nauth0/src/index.ts
@@ -14,3 +14,4 @@ export default (opts: NAuth0Options): NAuth0Client => {
 
 export * from './browser';
 export * from './server';
+export * from './lib';

--- a/packages/nauth0/src/server/session.ts
+++ b/packages/nauth0/src/server/session.ts
@@ -1,11 +1,11 @@
 import { TokenSet } from 'openid-client';
 import { NAuth0Options } from './config';
-import { Session } from 'lib';
+import { Session } from '../lib';
 import SignJWT from 'jose/jwt/sign';
 import jwtVerify from 'jose/jwt/verify';
 import { parseCookies } from 'nookies';
 import { sessionCookie } from './cookies';
-import { GetSessionOpts } from 'client';
+import { GetSessionOpts } from '../client';
 
 export interface Token {
   session: Session;

--- a/packages/nauth0/tsconfig.json
+++ b/packages/nauth0/tsconfig.json
@@ -17,7 +17,6 @@
     "alwaysStrict": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
-    "baseUrl": "src",
     "skipLibCheck": true,
     "jsx": "preserve"
   },


### PR DESCRIPTION
Closes: #32 

- Fixes the missing types
- Typescript doesn't rewrite absolute imports
- The project isn't that large or complex that it's a dealbreaker to just use relative imports

Note that in the future we might use Rollup or Babel transforms to handle this.