### PR TITLE
Replace setup-node action with Volta

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,10 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Use Node.js
-        uses: actions/setup-node@v2-beta
-        with:
-          node-version: '12'
+      - uses: volta-cli/action@v1
       - name: Install dependencies
         run: yarn install --frozen-lockfile --silent
       - name: Lint


### PR DESCRIPTION
### What are the changes?

Uses Volta to install node and yarn. This allows us to have a single source of truth for these versions 🥳 

### Checklist

- [ ] Documentation
- [ ] Tests

### First time contributor?

- [ ] Add your contributions to the README. [Instructions](/CONTRIBUTING.md)
